### PR TITLE
Remove gnu-11@macos-12 from build matrix

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -112,7 +112,6 @@ jobs:
         - clang-12@ubuntu-20.04
         - gnu-11@ubuntu-22.04
         - clang-14@ubuntu-22.04
-        - gnu-11@macos-12
         - clang-14@macos-12
         include:
         - name: gnu-10@ubuntu-20.04
@@ -138,12 +137,6 @@ jobs:
           compiler: clang-14
           compiler_cc: clang-14
           compiler_cxx: clang++-14
-          compiler_fc: gfortran-11
-        - name: gnu-11@macos-12
-          os: macos-12
-          compiler: gnu-11
-          compiler_cc: gcc-11
-          compiler_cxx: g++-11
           compiler_fc: gfortran-11
         # Xcode compiler requires empty environment variables, so we pass null (~) here
         - name: clang-14@macos-12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,6 @@ jobs:
         - clang-12@ubuntu-20.04
         - gnu-11@ubuntu-22.04
         - clang-14@ubuntu-22.04
-        - gnu-11@macos-12
         - clang-14@macos-12
         include:
         - name: gnu-10@ubuntu-20.04
@@ -105,12 +104,6 @@ jobs:
           compiler: clang-14
           compiler_cc: clang-14
           compiler_cxx: clang++-14
-          compiler_fc: gfortran-11
-        - name: gnu-11@macos-2
-          os: macos-12
-          compiler: gnu-11
-          compiler_cc: gcc-11
-          compiler_cxx: g++-11
           compiler_fc: gfortran-11
         # Xcode compiler requires empty environment variables, so we pass null (~) here
         - name: clang-14@macos-12

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,8 +57,6 @@ jobs:
     needs: qa
     uses: ./.github/workflows/ci-python.yml
     with:
-      skip_matrix_jobs: |
-        gnu-11@macos-12
       repository: ecmwf/pyodc
       ref: develop
       build_package_inputs: |


### PR DESCRIPTION
There's a linker bug which hits some of our packages. We'll test clang on mac & gnu on linux.