### PR TITLE
Specify commit hash for 3rd party actions

### DIFF
--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -140,7 +140,7 @@ jobs:
 
     - name: Codecov Upload
       if: inputs.self_test && inputs.codecov_upload && matrix.os == 'ubuntu-20.04' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
 
   notify:
     name: notify

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -211,7 +211,7 @@ jobs:
 
     - name: Codecov Upload
       if: inputs.codecov_upload && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop')
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
 
   deploy:
     name: deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
 
     - name: Codecov Upload
       if: inputs.codecov_upload && steps.build-test.outputs.coverage_file && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop')
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
       with:
         files: ${{ steps.build-test.outputs.coverage_file }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,9 @@ jobs:
 
     - name: Missing Dependency Cache
       if: inputs.deps_cache_key && steps.deps-cache.outputs.cache-hit != 'true'
-      uses: cutenode/action-always-fail@v1
+      run: |
+        echo "::error::Missing dependency cache for given deps_cache_key input."
+        exit 1
 
     - name: Setup Dependency Environment
       if: steps.deps-cache.outputs.cache-hit == 'true'


### PR DESCRIPTION
`codecov/codecov-action` was changed to last v3 commit hash.
`cutenode/action-always-fail` was possible to remove altogether and replace with native workflow command.