### PR TITLE
Add reusable wf for build-package-hpc

### DIFF
--- a/.github/workflows/ci-hpc.yml
+++ b/.github/workflows/ci-hpc.yml
@@ -17,9 +17,6 @@ on:
         type: boolean
         required: false
         default: false
-    secrets:
-      PAT:
-        required: true
 
 jobs:
   setup:
@@ -46,4 +43,4 @@ jobs:
       - name: Run build-package-hpc
         run: |
           cd ~/build-package-hpc
-          poetry run python -m build_package_hpc build ${{ needs.setup.outputs.inputs }} --github-user=${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }} --github-token=${{ secrets.PAT }}
+          poetry run python -m build_package_hpc build ${{ needs.setup.outputs.inputs }} --github-user=${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }} --github-token=${{ secrets.GH_REPO_READ_TOKEN }}

--- a/.github/workflows/ci-hpc.yml
+++ b/.github/workflows/ci-hpc.yml
@@ -1,0 +1,49 @@
+# Reusable workflow to build on HPC
+name: ci-hpc
+
+on:
+  workflow_call:
+    inputs:
+      build-inputs:
+        description: build inputs in yaml object
+        type: string
+        required: true
+      name-prefix:
+        description: Prefix for job names, usually repo name.
+        type: string
+        required: false
+      dev-runner:
+        description: Whether to use runner with dev version of build-package-hpc .
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      PAT:
+        required: true
+
+jobs:
+  setup:
+    name: ${{ inputs.name-prefix }}setup
+    runs-on: ubuntu-latest
+    outputs:
+      inputs: ${{ steps.prepare-inputs.outputs.inputs }}
+    steps:
+      - name: prepare inputs
+        id: prepare-inputs
+        shell: bash
+        run: |
+          props=$(echo '${{ inputs.build-inputs }}' | yq eval '.' --output-format props - | sed 's/ *//g; s/\\n/,/g; s/,$//')
+          echo inputs=$props >> $GITHUB_OUTPUT
+      - run: echo ${{ steps.prepare-inputs.outputs.inputs }}
+
+  build:
+    name: ${{ inputs.name-prefix }}build
+    runs-on:
+      [self-hosted, linux, "${{ inputs.dev-runner && 'hpc-dev' || 'hpc' }}"]
+    needs:
+      - setup
+    steps:
+      - name: Run build-package-hpc
+        run: |
+          cd ~/build-package-hpc
+          poetry run python -m build_package_hpc build ${{ needs.setup.outputs.inputs }} --github-user=${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }} --github-token=${{ secrets.PAT }}

--- a/.github/workflows/ci-hpc.yml
+++ b/.github/workflows/ci-hpc.yml
@@ -43,4 +43,4 @@ jobs:
       - name: Run build-package-hpc
         run: |
           cd ~/build-package-hpc
-          poetry run python -m build_package_hpc build ${{ needs.setup.outputs.inputs }} --github-user=${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }} --github-token=${{ secrets.GH_REPO_READ_TOKEN }}
+          poetry run python -m build_package_hpc build ${{ needs.setup.outputs.inputs }} --github-user=${{ secrets.BUILD_PACKAGE_HPC_GITHUB_USER }} --github-token=${{ secrets.GH_REPO_READ_TOKEN }} --troika-user=${{ secrets.HPC_CI_SSH_USER }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,3 +100,18 @@ jobs:
       system_dependencies: pandoc
       repository: ecmwf/pyodc
       ref: develop
+
+  ci-hpc:
+    name: ci-hpc
+    needs: qa
+    uses: ./.github/workflows/ci-hpc.yml
+    with:
+      name-prefix: eccodes-
+      build-inputs: |
+        --package: ecmwf/eccodes@develop
+        --modules: |
+          ecbuild
+          ninja
+        --parallel: 64
+    secrets:
+      PAT: ${{ secrets.PAT }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,5 +113,4 @@ jobs:
           ecbuild
           ninja
         --parallel: 64
-    secrets:
-      PAT: ${{ secrets.PAT }}
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A collection of [reusable GitHub workflows] for ECMWF repositories.
 ## Workflows
 
 * [ci.yml](#ciyml): Continuous Integration workflow for ecbuild/CMake-based projects
+* [ci-hpc.yml](#ci-hpcyml): Continuous Integration workflow for ecbuild/CMake-based projects on HPC
 * [ci-python.yml](#ci-pythonyml): Continuous Integration and Continuous Deployment workflow for Python-based projects
 * [ci-node.yml](#ci-nodeyml): Continuous Integration workflow for NodeJS-based projects
 * [docs.yml](#docsyml): Workflow for testing Sphinx-based documentation
@@ -102,6 +103,49 @@ Optional [inputs for the build-package] action, provided as a YAML object value.
 
 Public URL of the Microsoft Teams incoming webhook. To get the value, make sure that channel in Teams has the appropriate connector set up. It will only be used if [notify_teams](#notify_teams) input is switched on.
 **Example:** `https://webhook.office.com/webhookb2/...`
+
+## ci-hpc.yml
+
+### Usage
+
+```yaml
+jobs:
+  ci-hpc:
+    name: ci-hpc
+    uses: ecmwf-actions/reusable-workflows/.github/workflows/ci-hpc.yml@v2
+    with:
+      name-prefix: metkit-
+      build-inputs: |
+        --package: ecmwf/metkit@develop
+        --modules: |
+          ecbuild
+          ninja
+        --dependencies: |
+          ecmwf/eccodes@develop
+          ecmwf/eckit@develop
+        --parallel: 64
+    secrets: inherit\
+```
+
+### Inputs
+
+#### `name-prefix`
+
+Job name prefix. Usually the package name. Suitable when building multiple packages within one workflow to easily differentiate between them.
+**Default:** `''`
+**Type:** `string`
+
+#### `build-inputs`
+
+Inputs for `build-package-hpc` action.
+**Default:** `''`
+**Type:** `string`
+
+#### `dev-runner`
+
+Whether to build using development runner which contains latest version of `build-package-hpc`. 
+**Default:** `''`
+**Type:** `string`
 
 ## ci-python.yml
 


### PR DESCRIPTION
Moved `ci-hpc.yml` from `build-package-hpc` repo.
Added test to cover the reusable wf. 