### PR TITLE
New reusable workflow for management of pull request labels

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,25 @@
+name: PR label
+
+on:
+  workflow_call:
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.fork }}
+    steps:
+      - name: Add label `contributor`
+        if: ${{ github.event.action == 'opened' }}
+        uses: ecmwf-actions/labeler@v1
+        with:
+          issue: ${{ github.event.number }}
+          label: contributor
+          action: add
+
+      - name: Remove label `approved-for-ci`
+        if: ${{ github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'approved-for-ci') }}
+        uses: ecmwf-actions/labeler@v1
+        with:
+          issue: ${{ github.event.number }}
+          label: approved-for-ci
+          action: remove

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,4 +1,4 @@
-name: PR label
+name: Label PR
 
 on:
   workflow_call:

--- a/README.md
+++ b/README.md
@@ -431,6 +431,23 @@ The user access token with read access to the source repository, must be URL-enc
 **Required** The user access token with write access to the target repository, must be URL-encoded.
 **Example:** `...`
 
+
+## label-pr.yml
+Manages labels on public pull requests. `contributor` label is added when a PR from public fork is opened. Removes label `approved-for-ci` when pull request HEAD changes.
+### Usage
+
+```yaml
+on:
+  # trigger the pull request is opened or pushed to
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  label:
+    uses: ecmwf-actions/reusable-workflows/.github/workflows/pr-label.yml@v2
+```
+
+
 ## Development
 
 ### Install Dependencies


### PR DESCRIPTION
Adds reusable workflow to call `ecmwf-action/labeler` action. Workflow adds label `contributor` to public pull requests and removes label `approved-for-ci` from previously approved PRs which were pushed to.