### PR TITLE
Separate code coverage job from build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,7 @@ jobs:
 
   test:
     name: ${{ inputs.name_prefix }}test-${{ matrix.name }}
+    if: ${{ !inputs.codecov_upload }}
     needs:
     - setup
     strategy:


### PR DESCRIPTION
Do not run builds for matrix when generating code coverage, to allow separate codecov job from downstream-ci.