### PR TITLE
Add path ignore input to formatting check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,10 @@ on:
         description: Whether to check code formatting using clang-format.
         required: false
         type: boolean
+      format_ignore_paths:
+        description: A list of paths to be skipped during formatting check.
+        required: false
+        type: string
       notify_teams:
         description: Whether to notify about workflow status via Microsoft Teams. Note that you must supply
           `incoming_webhook` secret if you switch on this feature.
@@ -182,7 +186,9 @@ jobs:
       if: inputs.check_formatting
       shell: bash {0}
       run: |
-        files=$(find . -regex ".*\.\(cpp\|hpp\|cc\|cxx\|h\|c\)")
+        ignore="./\($(echo "${{ inputs.format_ignore_paths }}" | sed ':a;N;$!ba;s/\n/\\|/g')\)"
+        echo "Ignore: $ignore"
+        files=$(find . -not \( -regex $ignore -prune \) -regex ".*\.\(cpp\|hpp\|cc\|cxx\|h\|c\)")
         errors=0
         
         if [ ! -e ".clang-format" ]


### PR DESCRIPTION
Adds `format_ignore_paths` input to allow skipping certain paths during the formatting check.