### PR TITLE
Adjust codecov for atlas and mir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
         shell: bash -eux {0}
         run: >
           echo inputs=$(echo '${{ inputs.build_package_inputs || '{}' }}' |
-          yq eval '.github_token="${{ secrets.GH_REPO_READ_TOKEN || github.token }}" | .save_cache="false" | .os="ubuntu-22.04"
+          yq eval '.github_token="${{ secrets.GH_REPO_READ_TOKEN || github.token }}" | .cache_suffix="-codecov" | .os="ubuntu-22.04"
           | .compiler="gnu" | .compiler_cc="gcc" | .compiler_cxx="g++" | .compiler_fc="gfortran"'
           --output-format json --indent 0 -) >> $GITHUB_OUTPUT
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,13 @@ jobs:
           | .compiler="gnu" | .compiler_cc="gcc" | .compiler_cxx="g++" | .compiler_fc="gfortran"'
           --output-format json --indent 0 -) >> $GITHUB_OUTPUT
 
+      # Tempororary solution to get fftw for mir on github hosted runner
+      - name: install fftw for MIR
+        if: ${{ contains(steps.prepare-inputs.outputs.inputs, 'ecmwf/mir') }}
+        run: |
+          sudo apt update
+          sudo apt install -y -q libfftw3-dev
+
       - name: Build & Collect code coverage report
         id: build
         uses: ecmwf-actions/build-package@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,8 @@ jobs:
         shell: bash -eux {0}
         run: >
           echo inputs=$(echo '${{ inputs.build_package_inputs || '{}' }}' |
-          yq eval '.github_token="${{ secrets.GH_REPO_READ_TOKEN || github.token }}" | .cache_suffix="-codecov" | .os="ubuntu-22.04"
+          yq eval '.github_token="${{ secrets.GH_REPO_READ_TOKEN || github.token }}" | .parallelism_factor="2"
+          | .cache_suffix="-codecov" | .os="ubuntu-22.04"
           | .compiler="gnu" | .compiler_cc="gcc" | .compiler_cxx="g++" | .compiler_fc="gfortran"'
           --output-format json --indent 0 -) >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Installs fftw if building codecov for mir. 
Enable caching codecov builds, but with suffix to not compromise cache for regular builds.
Build and test with 2 threads on the github hosted runner, as that is the maximum.