### PR TITLE
Allow HPC compiler matrix

### DIFF
--- a/ci-hpc/action.yml
+++ b/ci-hpc/action.yml
@@ -38,6 +38,10 @@ inputs:
     description: Fortran compiler.
     required: true
     default: ${{ matrix.compiler_fc }}
+  compiler_modules:
+    description: List of compilers to be loaded as modules.
+    required: false
+    default: ${{ matrix.compiler_modules }}
 
 runs:
   using: composite
@@ -73,4 +77,5 @@ runs:
         --compiler=${{ inputs.compiler }} \
         --compiler-cc=${{ inputs.compiler_cc }} \
         --compiler-cxx=${{ inputs.compiler_cxx }} \
-        --compiler-fc=${{ inputs.compiler_fc }}
+        --compiler-fc=${{ inputs.compiler_fc }} \
+        --compiler-modules=${{ inputs.compiler_modules }}

--- a/ci-hpc/action.yml
+++ b/ci-hpc/action.yml
@@ -69,6 +69,7 @@ runs:
       run: |
         cd ~/build-package-hpc
         poetry run python -m build_package_hpc --config=$GITHUB_WORKSPACE/${{ inputs.build_config }} \
+        --config-name=${{ inputs.compiler }} \
         build --package=${{ inputs.repository }} \
         --dependencies=${{ steps.inputs.outputs.deps }} \
         --github-user=${{ inputs.github_user }} \


### PR DESCRIPTION
Adds `compiler_modules` input to pass list of compiler modules to build-package-hpc to be loaded.