### PR TITLE
Pass build config name to build-package-hpc

### DIFF
--- a/ci-hpc/action.yml
+++ b/ci-hpc/action.yml
@@ -42,6 +42,10 @@ inputs:
     description: List of compilers to be loaded as modules.
     required: false
     default: ${{ matrix.compiler_modules }}
+  build_config_key:
+    description: Config name in the build config file.
+    required: false
+    default: ${{ matrix.config }}
 
 runs:
   using: composite
@@ -70,7 +74,7 @@ runs:
       run: |
         cd ~/build-package-hpc
         poetry run python -m build_package_hpc --config=$GITHUB_WORKSPACE/${{ inputs.build_config }} \
-        --config-name=${{ inputs.compiler }} \
+        --config-name=${{ inputs.build_config_key }} \
         build --package=${{ inputs.repository }} \
         --dependencies=${{ steps.inputs.outputs.deps }} \
         --github-user=${{ inputs.github_user }} \


### PR DESCRIPTION
Add `build_config_key` input to `ci-hpc` action with default value coming from matrix. Allows extending matrix with multiple build configurations.