### PR TITLE
Separate QA jobs

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,49 @@
+name: clang-format
+
+on:
+  workflow_call:
+    inputs:
+      ignore_paths:
+        description: A list of paths to be skipped during formatting check.
+        required: false
+        type: string
+
+jobs:
+  check-formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install clang-format
+        run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main
+          sudo apt update
+          sudo apt install -y clang-format-16
+
+      - name: Run clang-format
+        shell: bash {0}
+        run: |
+          ignore="./\($(echo "${{ inputs.ignore_paths }}" | sed ':a;N;$!ba;s/\n/\\|/g')\)"
+          echo "Ignore: $ignore"
+          files=$(find . -not \( -regex $ignore -prune \) -regex ".*\.\(cpp\|hpp\|cc\|cxx\|h\|c\)")
+          errors=0
+
+          if [ ! -e ".clang-format" ]
+          then
+              echo "::error::Missing .clang-format file"
+              exit 1
+          fi
+
+          for file in $files; do
+              clang-format-16 --dry-run --Werror --style=file --fallback-style=none $file
+              if [ $? -ne 0 ]; then
+                  ((errors++))
+              fi
+          done
+
+          if [ $errors -ne 0 ]; then
+              echo "::error::clang-format failed for $errors files"
+              exit 1
+          fi

--- a/build-package-with-config/action.yml
+++ b/build-package-with-config/action.yml
@@ -24,6 +24,9 @@ inputs:
     description: Github token with read access to needed repositories.
     required: false
     default: ${{ github.token }}
+  codecov_upload:
+    description: Whether to upload code coverage to codecov service, only for master, develop and PRs.
+    required: false
 
 runs:
   using: composite
@@ -85,6 +88,8 @@ runs:
 
         combined = {**config, **inputs}
 
+        combined["self_coverage"] = "${{ inputs.codecov_upload == 'true' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || contains(github.event_name, 'pull_request')) }}"
+
         print("Combined inputs:\n", yaml.dump(combined, sort_keys=False), sep='')
 
         with open(os.getenv("GITHUB_OUTPUT"), "a") as f:
@@ -96,6 +101,12 @@ runs:
       id: build
       uses: ecmwf-actions/build-package@v2
       with: ${{ fromJSON(steps.config.outputs.config) }}
+
+    - name: Codecov Upload
+      if: ${{ inputs.codecov_upload == 'true' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || contains(github.event_name, 'pull_request')) && steps.build.outputs.coverage_file }}
+      uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d
+      with:
+        files: ${{ steps.build.outputs.coverage_file }}
 
 outputs:
   lib_path:


### PR DESCRIPTION
Move clang format check to a separate workflow.
Add codecov upload step to build-package wrapper action, so it's possible to generate codecov report on self-hosted runners.