### PR TITLE
Fix `create-package.yml` version check

### DIFF
--- a/.github/workflows/create-package.yml
+++ b/.github/workflows/create-package.yml
@@ -27,6 +27,8 @@ jobs:
             upload_url: NEXUS_REPO_URL_DEBIAN_11
     runs-on: ${{ matrix.labels }}
     steps:
+      - uses: actions/checkout@v3
+
       - name: Check version number
         shell: python3 {0}
         run: |


### PR DESCRIPTION
Repository checkout was missing before version verification step => it was comparing the tag against whatever was built on the runner before.