### PR TITLE
Support installing python packages as dependencies

### DIFF
--- a/ci-hpc/action.yml
+++ b/ci-hpc/action.yml
@@ -22,6 +22,9 @@ inputs:
   dependencies:
     description: List of build dependencies in format `owner/repo@ref`. Adds to whatever is specified in the build configuration file, if the same owner/repo is present, the ref is overridden.
     required: false
+  python_dependencies:
+    description: List of python dependencies to build from source in format `owner/repo@ref`
+    required: false
   compiler:
     description: Compiler family.
     required: true
@@ -61,10 +64,12 @@ runs:
         import os
         repo, ref = "${{ inputs.repository }}".split("@")
         deps = ",".join("""${{ inputs.dependencies }}""".splitlines())
+        py_deps = ",".join("""${{ inputs.python_dependencies }}""".splitlines())
         with open(os.getenv("GITHUB_OUTPUT"), "a") as f:
             print("repo", repo, sep="=", file=f)
             print("ref", ref, sep="=", file=f)
             print("deps", deps, sep="=", file=f)
+            print("py_deps", py_deps, sep="=", file=f)
 
     - name: Checkout repository
       uses: actions/checkout@v3
@@ -89,4 +94,5 @@ runs:
         --compiler-cxx=${{ inputs.compiler_cxx }} \
         --compiler-fc=${{ inputs.compiler_fc }} \
         --compiler-modules=${{ inputs.compiler_modules }} \
-        --python=${{ inputs.python_version }}
+        --python=${{ inputs.python_version }} \
+        --python-dependencies=${{ steps.inputs.outputs.py_deps }}

--- a/ci-python/action.yml
+++ b/ci-python/action.yml
@@ -77,8 +77,8 @@ runs:
           repo="${repo_ref%%@*}"
           ref="${repo_ref#*@}"
           
-          mkdir -p $GITHUB_WORKSPACE/ci-deps/$repo
-          cd $GITHUB_WORKSPACE/ci-deps/$repo
+          mkdir -p $RUNNER_TEMP/ci-deps/$repo
+          cd $RUNNER_TEMP/ci-deps/$repo
           git init
           git remote add origin https://${{ inputs.github_token }}@github.com/$owner/$repo.git
           git fetch --depth 1 origin $ref

--- a/ci-python/action.yml
+++ b/ci-python/action.yml
@@ -53,8 +53,8 @@ runs:
       shell: bash -e {0}
       run: |
         source /opt/conda/etc/profile.d/conda.sh
-        conda create -y -p venv
-        conda activate ./venv
+        conda create -y -p $RUNNER_TEMP/venv
+        conda activate $RUNNER_TEMP/venv
         conda install -y python=${{ inputs.python_version }}
         if [ -n "${{ inputs.conda_install }}" ]; then
           conda install -y ${{ inputs.conda_install }}
@@ -69,7 +69,7 @@ runs:
       shell: bash -e {0}
       run: |
         source /opt/conda/etc/profile.d/conda.sh
-        conda activate ./venv
+        conda activate $RUNNER_TEMP/venv
 
         while IFS= read -r line && [[ -n "$line" ]]; do
           owner="${line%%/*}"
@@ -91,7 +91,7 @@ runs:
       shell: bash -e {0}
       run: |
         source /opt/conda/etc/profile.d/conda.sh
-        conda activate ./venv
+        conda activate $RUNNER_TEMP/venv
         python setup.py sdist
         pip install dist/*
 
@@ -101,6 +101,6 @@ runs:
       shell: bash -e {0}
       run: |
         source /opt/conda/etc/profile.d/conda.sh
-        conda activate ./venv
+        conda activate $RUNNER_TEMP/venv
         pytest --cov=./ --cov-report=xml
         python -m coverage report

--- a/ci-python/action.yml
+++ b/ci-python/action.yml
@@ -23,6 +23,9 @@ inputs:
   repository:
     description: Repository name in format owner/repo@ref.
     required: false
+  python_dependencies:
+    description: List of python packages to install from source as dependencies. In format owner/repo@ref, multiline for multiple packages.
+    required: false
 
 runs:
   using: composite
@@ -60,6 +63,29 @@ runs:
         if [ -f ${{ inputs.requirements_path }} ]; then
           pip install -r ${{ inputs.requirements_path }} 
         fi
+
+    - name: Install dependencies
+      if: ${{ inputs.python_dependencies }}
+      shell: bash -e {0}
+      run: |
+        source /opt/conda/etc/profile.d/conda.sh
+        conda activate ./venv
+
+        while IFS= read -r line && [[ -n "$line" ]]; do
+          owner="${line%%/*}"
+          repo_ref="${line#*/}"
+          repo="${repo_ref%%@*}"
+          ref="${repo_ref#*@}"
+          
+          mkdir -p $GITHUB_WORKSPACE/ci-deps/$repo
+          cd $GITHUB_WORKSPACE/ci-deps/$repo
+          git init
+          git remote add origin https://${{ inputs.github_token }}@github.com/$owner/$repo.git
+          git fetch --depth 1 origin $ref
+          git checkout FETCH_HEAD
+          python setup.py sdist
+          pip install dist/*
+        done <<< "${{ inputs.python_dependencies }}"
 
     - name: Install package
       shell: bash -e {0}


### PR DESCRIPTION
Adds support for installing python packages from source as dependencies for other python packages.
ci-python: changes the location of virtual environment to `runner.temp`, so that pytest does not run tests on all installed packages.