### PR TITLE
Set environment variables from matrix

### DIFF
--- a/build-package-with-config/action.yml
+++ b/build-package-with-config/action.yml
@@ -27,6 +27,10 @@ inputs:
   codecov_upload:
     description: Whether to upload code coverage to codecov service, only for master, develop and PRs.
     required: false
+  env:
+    description: List of environment variables in format `VAR=value`
+    required: false
+    default: ${{ matrix.env }}
 
 runs:
   using: composite
@@ -47,6 +51,11 @@ runs:
         repository: ${{ steps.inputs.outputs.repo }}
         ref: ${{ steps.inputs.outputs.ref }}
         token: ${{ inputs.github_token }}
+
+    - name: Set env vars from matrix
+      if: ${{ inputs.env }}
+      shell: bash -e {0}
+      run: echo "${{ inputs.env }}" >> "$GITHUB_ENV"
 
     - name: Merge inputs with config file
       id: config

--- a/ci-python/action.yml
+++ b/ci-python/action.yml
@@ -26,6 +26,10 @@ inputs:
   python_dependencies:
     description: List of python packages to install from source as dependencies. In format owner/repo@ref, multiline for multiple packages.
     required: false
+  env:
+    description: List of environment variables in format `VAR=value`
+    required: false
+    default: ${{ matrix.env }}
 
 runs:
   using: composite
@@ -48,6 +52,11 @@ runs:
         repository: ${{ steps.inputs.outputs.repo }}
         ref: ${{ steps.inputs.outputs.ref }}
         token: ${{ inputs.github_token }}
+
+    - name: Set env vars from matrix
+      if: ${{ inputs.env }}
+      shell: bash -e {0}
+      run: echo "${{ inputs.env }}" >> "$GITHUB_ENV"
 
     - name: Setup python env
       shell: bash -e {0}


### PR DESCRIPTION
Adds an input for environment variables to `build-package-with-config` and `ci-python` actions. Takes value from matrix by default. Usable when setting env. var. per runner.