### PR TITLE
Support toml

### DIFF
--- a/ci-hpc/action.yml
+++ b/ci-hpc/action.yml
@@ -28,6 +28,9 @@ inputs:
   python_requirements:
     description: Path to pip requirements file for python packages.
     required: false
+  python_toml_opt_dep_sections:
+    description: List of optional dependency sections specified in pyproject.toml. ' ' to only install default deps.
+    required: false
   conda_deps:
     description: List of conda packages to be installed into the environment.
     required: false
@@ -122,6 +125,7 @@ runs:
         --python=${{ inputs.python_version }} \
         --conda-deps=${{ inputs.conda_deps }} \
         ${{ inputs.python_requirements && format('--requirements={0}', inputs.python_requirements) }} \
+        ${{ inputs.python_toml_opt_dep_sections && format('--toml-opt-dep_sections={0}', inputs.python_toml_opt_dep_sections) }} \
         --python-dependencies=${{ steps.inputs.outputs.py_deps }} \
         --workdir=${{ inputs.workdir }} \
         --output-dir=${{ inputs.output_dir }}

--- a/ci-hpc/action.yml
+++ b/ci-hpc/action.yml
@@ -125,7 +125,7 @@ runs:
         --python=${{ inputs.python_version }} \
         --conda-deps=${{ inputs.conda_deps }} \
         ${{ inputs.python_requirements && format('--requirements={0}', inputs.python_requirements) }} \
-        ${{ inputs.python_toml_opt_dep_sections && format('--toml-opt-dep_sections={0}', inputs.python_toml_opt_dep_sections) }} \
+        ${{ inputs.python_toml_opt_dep_sections && format('--toml-opt-dep-sections={0}', inputs.python_toml_opt_dep_sections) }} \
         --python-dependencies=${{ steps.inputs.outputs.py_deps }} \
         --workdir=${{ inputs.workdir }} \
         --output-dir=${{ inputs.output_dir }}

--- a/ci-python/action.yml
+++ b/ci-python/action.yml
@@ -4,6 +4,9 @@ inputs:
   requirements_path:
     description: Path to pip requirements file.
     default: requirements.txt
+  toml_opt_dep_sections:
+    description: List of optional dependency sections specified in pyproject.toml. ' ' to only install default deps.
+    required: false
   lib_path:
     description: LD_LIBRARY_PATH containing paths to depedency libraries.
     required: false
@@ -84,6 +87,10 @@ runs:
         pip install pytest pytest-cov build
         if [ -f ${{ inputs.requirements_path }} ]; then
           pip install -r ${{ inputs.requirements_path }} 
+        fi
+        # this is just to install the dependencies; the pkg will be overwritten later
+        if [ -n "${{ inputs.toml_opt_dep_sections }}" ]; then
+          pip install -e .[${{ inputs.toml_opt_dep_sections }}]
         fi
 
     - name: Install dependencies


### PR DESCRIPTION
Allow packages to specify optional dependency sections from a pyproject.toml file in order to install deps for ci.