### PR TITLE
Remove centos7 from create-package

### DIFF
--- a/.github/workflows/create-package.yml
+++ b/.github/workflows/create-package.yml
@@ -47,7 +47,8 @@ jobs:
       matrix:
         name:
           - gnu@debian-11
-          - gnu-8@centos-7.9
+          # centos 7 is not compatible with node20
+          # - gnu-8@centos-7.9
           - gnu@rocky-8.6
         include:
           - name: gnu@debian-11
@@ -65,19 +66,19 @@ jobs:
               -DCPACK_DEBIAN_PACKAGE_SHLIBDEPS=ON
             upload_token: NEXUS_TEST_REPO_UPLOAD_TOKEN
             upload_url: NEXUS_TEST_REPO_URL_DEBIAN_11
-          - name: gnu-8@centos-7.9
-            labels: [self-hosted, platform-builder-centos-7.9]
-            os: centos-7.9
-            compiler: gnu-8
-            compiler_cc: gcc-8
-            compiler_cxx: g++-8
-            compiler_fc: gfortran-8
-            cpack_generator: RPM
-            cpack_options: >
-              -D CPACK_PACKAGING_INSTALL_PREFIX=/opt/ecmwf 
-              ${{ inputs.cpack_options_rpm }}
-            upload_token: NEXUS_TEST_REPO_UPLOAD_TOKEN
-            upload_url: NEXUS_TEST_REPO_URL_CENTOS_7
+          # - name: gnu-8@centos-7.9
+          #   labels: [self-hosted, platform-builder-centos-7.9]
+          #   os: centos-7.9
+          #   compiler: gnu-8
+          #   compiler_cc: gcc-8
+          #   compiler_cxx: g++-8
+          #   compiler_fc: gfortran-8
+          #   cpack_generator: RPM
+          #   cpack_options: >
+          #     -D CPACK_PACKAGING_INSTALL_PREFIX=/opt/ecmwf
+          #     ${{ inputs.cpack_options_rpm }}
+          #   upload_token: NEXUS_TEST_REPO_UPLOAD_TOKEN
+          #   upload_url: NEXUS_TEST_REPO_URL_CENTOS_7
           - name: gnu@rocky-8.6
             labels: [self-hosted, platform-builder-rocky-8.6]
             os: rocky-8.6


### PR DESCRIPTION
Because Centos7 is not compatible with Node20 and therefore the GitHub runners will no longer function on it.