### PR TITLE
Allow cd-pypi.yml to accept args for alternative twine/pypi uploads

### DIFF
--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -3,7 +3,17 @@ name: cd-pypi
 
 on:
   workflow_call:
-
+    inputs:
+      extra_twine_args:
+        description: extra arguments for 'twine upload'
+        type: string
+        required: false
+        default: ""
+      pypi_token:
+        description: alternative token for uploading to pypi
+        type: string
+        required: false
+        default: ${{ secrets.PYPI_API_TOKEN }}
 jobs:
   deploy:
     if: ${{ github.ref_type == 'tag' || github.event_name == 'release' }}
@@ -32,7 +42,7 @@ jobs:
     - name: Build and publish
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        TWINE_PASSWORD: ${{ pypi_token }}
       run: |
         python -m build
-        twine upload dist/*
+        twine upload ${{ extra_twine_args }} dist/*


### PR DESCRIPTION
Specifically so we can upload to testpypi