### PR TITLE
testpypi as option to cd-pypi

### DIFF
--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   deploy:
-    #if: ${{ github.ref_type == 'tag' || github.event_name == 'release' }}
+    if: ${{ github.ref_type == 'tag' || github.event_name == 'release' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -34,7 +34,7 @@ jobs:
         if [ -f "setup.py" ]; then
           release=${{ github.ref_name }}
           version=$(python setup.py --version)
-          # test "$release" == "$version"
+          test "$release" == "$version"
         fi
 
     - name: Build and publish to pypi

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -50,7 +50,7 @@ jobs:
       if: ${{ inputs.testpypi }}
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ ( secrets.PYPI_TEST_API_TOKEN) || secrets.PYPI_API_TOKEN }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_TEST_API_TOKEN }}
       run: |
         python -m build
         twine upload --repository testpypi dist/*

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   deploy:
-    if: ${{ github.ref_type == 'tag' || github.event_name == 'release' }}
+    #if: ${{ github.ref_type == 'tag' || github.event_name == 'release' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -34,7 +34,7 @@ jobs:
         if [ -f "setup.py" ]; then
           release=${{ github.ref_name }}
           version=$(python setup.py --version)
-          test "$release" == "$version"
+          # test "$release" == "$version"
         fi
 
     - name: Build and publish to pypi

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -4,15 +4,13 @@ name: cd-pypi
 on:
   workflow_call:
     inputs:
-      extra_twine_args:
-        description: extra arguments for 'twine upload'
-        type: string
+      testpypi:
+        description:
+          Whether to upload to testpypi instead of pypi.
+          Requires secrets.PYPI_TEST_API_TOKEN to be defined.
+        type: boolean
         required: false
-        default: ""
-    secrets:  
-      pypi_token:
-        description: alternative token for uploading to pypi
-        required: false
+        default: false
 
 jobs:
   deploy:
@@ -39,10 +37,20 @@ jobs:
           test "$release" == "$version"
         fi
 
-    - name: Build and publish
+    - name: Build and publish to pypi
+      if: ${{ !inputs.testpypi }}
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.pypi_token || secrets.PYPI_API_TOKEN }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: |
         python -m build
-        twine upload ${{ extra_twine_args }} dist/*
+        twine upload dist/*
+
+    - name: Build and publish to testpypi
+      if: ${{ inputs.testpypi }}
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ ( secrets.PYPI_TEST_API_TOKEN) || secrets.PYPI_API_TOKEN }}
+      run: |
+        python -m build
+        twine upload --repository testpypi dist/*

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -9,11 +9,11 @@ on:
         type: string
         required: false
         default: ""
+    secrets:  
       pypi_token:
         description: alternative token for uploading to pypi
-        type: string
         required: false
-        default: ${{ secrets.PYPI_API_TOKEN }}
+
 jobs:
   deploy:
     if: ${{ github.ref_type == 'tag' || github.event_name == 'release' }}
@@ -42,7 +42,7 @@ jobs:
     - name: Build and publish
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ pypi_token }}
+        TWINE_PASSWORD: ${{ secrets.pypi_token || secrets.PYPI_API_TOKEN }}
       run: |
         python -m build
         twine upload ${{ extra_twine_args }} dist/*


### PR DESCRIPTION
A package can now add the `testpypi` option to cd-pypi.yml. That package must have a secret called PYPI_TEST_API_TOKEN available to it. If set, the deployment will upload to the testpypi site instead of the standard one.
```
  pypi:
    uses: ecmwf-actions/reusable-workflows/.github/workflows/cd-pypi.yml@v2
    with:
      testpypi: true
    secrets: inherit
```