### PR TITLE
Reusable workflow for precommit hook runs

### DIFF
--- a/.github/workflows/qa-precommit-run.yml
+++ b/.github/workflows/qa-precommit-run.yml
@@ -1,0 +1,30 @@
+name: '[QA] Run pre-commit hooks'
+
+on:
+
+  # Allow the workflow to be reusable
+  workflow_call:
+    inputs:
+      # Inputs for pre-commit hooks action.
+      python_version:
+        description: The version of Python binary to use.
+        required: false
+        default: '3.x'
+        type: string
+      skip_hooks:
+        description: A list of pre-commit hooks to skip.
+        required: false
+        default: ''
+        type: string
+
+jobs:
+  pre-commit-run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python_version }}
+    - uses: pre-commit/action@v3.0.1
+      env:
+        SKIP: {{ inputs.skip_hooks }}

--- a/.github/workflows/qa-precommit-run.yml
+++ b/.github/workflows/qa-precommit-run.yml
@@ -6,12 +6,12 @@ on:
   workflow_call:
     inputs:
       # Inputs for pre-commit hooks action.
-      python_version:
+      python-version:
         description: The version of Python binary to use.
         required: false
         default: '3.x'
         type: string
-      skip_hooks:
+      skip-hooks:
         description: A list of pre-commit hooks to skip.
         required: false
         default: ''
@@ -26,8 +26,8 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ inputs.python_version }}
+        python-version: ${{ inputs.python-version }}
     - name: Run pre-commit hooks
       uses: pre-commit/action@v3.0.1
       env:
-        SKIP: ${{ inputs.skip_hooks }}
+        SKIP: ${{ inputs.skip-hooks }}

--- a/.github/workflows/qa-precommit-run.yml
+++ b/.github/workflows/qa-precommit-run.yml
@@ -21,10 +21,13 @@ jobs:
   pre-commit-run:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+    - name: Setup Python
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python_version }}
-    - uses: pre-commit/action@v3.0.1
+    - name: Run pre-commit hooks
+      uses: pre-commit/action@v3.0.1
       env:
         SKIP: {{ inputs.skip_hooks }}

--- a/.github/workflows/qa-precommit-run.yml
+++ b/.github/workflows/qa-precommit-run.yml
@@ -30,4 +30,4 @@ jobs:
     - name: Run pre-commit hooks
       uses: pre-commit/action@v3.0.1
       env:
-        SKIP: {{ inputs.skip_hooks }}
+        SKIP: ${{ inputs.skip_hooks }}

--- a/README.md
+++ b/README.md
@@ -8,19 +8,20 @@ A collection of [reusable GitHub workflows] for ECMWF repositories.
 
 ## Workflows
 
-* [ci.yml](#ciyml): Continuous Integration workflow for ecbuild/CMake-based projects
-* [ci-hpc.yml](#ci-hpcyml): Continuous Integration workflow for ecbuild/CMake-based projects on HPC
-* [ci-python.yml](#ci-pythonyml): Continuous Integration and Continuous Deployment workflow for Python-based projects
-* [ci-node.yml](#ci-nodeyml): Continuous Integration workflow for NodeJS-based projects
-* [docs.yml](#docsyml): Workflow for testing Sphinx-based documentation
-* [sync.yml](#syncyml): Workflow for syncing a Git repository
+-   [ci.yml](#ciyml): Continuous Integration workflow for ecbuild/CMake-based projects
+-   [ci-hpc.yml](#ci-hpcyml): Continuous Integration workflow for ecbuild/CMake-based projects on HPC
+-   [ci-python.yml](#ci-pythonyml): Continuous Integration and Continuous Deployment workflow for Python-based projects
+-   [ci-node.yml](#ci-nodeyml): Continuous Integration workflow for NodeJS-based projects
+-   [docs.yml](#docsyml): Workflow for testing Sphinx-based documentation
+-   [qa-precommit-run.yml](#qa-precommit): Runs the pre-commit hooks on all files server-side as a QA drop-in.
+-   [sync.yml](#syncyml): Workflow for syncing a Git repository
 
 [Samples]
 
 ## Supported Operating Systems
 
-* Linux
-* macOS
+-   Linux
+-   macOS
 
 ## ci.yml
 
@@ -28,23 +29,22 @@ A collection of [reusable GitHub workflows] for ECMWF repositories.
 
 ```yaml
 jobs:
-
-  # Calls a reusable CI workflow to build & test current repository.
-  #   It will pull in all needed dependencies and produce a code coverage report on success.
-  #   In case the job fails, a message will be posted to a Microsoft Teams channel.
-  ci:
-    name: ci
-    uses: ecmwf-actions/reusable-workflows/.github/workflows/ci.yml@v1
-    with:
-      codecov_upload: true
-      notify_teams: true
-      build_package_inputs: |
-        dependencies: |
-          ecmwf/ecbuild
-          ecmwf/eckit
-        dependency_branch: develop
-    secrets:
-      incoming_webhook: ${{ secrets.MS_TEAMS_INCOMING_WEBHOOK }}
+    # Calls a reusable CI workflow to build & test current repository.
+    #   It will pull in all needed dependencies and produce a code coverage report on success.
+    #   In case the job fails, a message will be posted to a Microsoft Teams channel.
+    ci:
+        name: ci
+        uses: ecmwf-actions/reusable-workflows/.github/workflows/ci.yml@v1
+        with:
+            codecov_upload: true
+            notify_teams: true
+            build_package_inputs: |
+                dependencies: |
+                  ecmwf/ecbuild
+                  ecmwf/eckit
+                dependency_branch: develop
+        secrets:
+            incoming_webhook: ${{ secrets.MS_TEAMS_INCOMING_WEBHOOK }}
 ```
 
 ### Inputs
@@ -110,21 +110,21 @@ Public URL of the Microsoft Teams incoming webhook. To get the value, make sure 
 
 ```yaml
 jobs:
-  ci-hpc:
-    name: ci-hpc
-    uses: ecmwf-actions/reusable-workflows/.github/workflows/ci-hpc.yml@v2
-    with:
-      name-prefix: metkit-
-      build-inputs: |
-        --package: ecmwf/metkit@develop
-        --modules: |
-          ecbuild
-          ninja
-        --dependencies: |
-          ecmwf/eccodes@develop
-          ecmwf/eckit@develop
-        --parallel: 64
-    secrets: inherit\
+    ci-hpc:
+        name: ci-hpc
+        uses: ecmwf-actions/reusable-workflows/.github/workflows/ci-hpc.yml@v2
+        with:
+            name-prefix: metkit-
+            build-inputs: |
+                --package: ecmwf/metkit@develop
+                --modules: |
+                  ecbuild
+                  ninja
+                --dependencies: |
+                  ecmwf/eccodes@develop
+                  ecmwf/eckit@develop
+                --parallel: 64
+        secrets: inherit\
 ```
 
 ### Inputs
@@ -143,7 +143,7 @@ Inputs for `build-package-hpc` action.
 
 #### `dev-runner`
 
-Whether to build using development runner which contains latest version of `build-package-hpc`. 
+Whether to build using development runner which contains latest version of `build-package-hpc`.
 **Default:** `''`
 **Type:** `string`
 
@@ -153,28 +153,27 @@ Whether to build using development runner which contains latest version of `buil
 
 ```yaml
 jobs:
-
-  # Calls a reusable CI workflow to qa, test & deploy the current repository.
-  #   It will pull in all needed dependencies and produce a code coverage report on success.
-  #   If all checks were successful and a new release tag pushed, the package will be published on PyPI.
-  #   In case the job fails, a message will be posted to a Microsoft Teams channel.
-  ci:
-    name: ci
-    uses: ecmwf-actions/reusable-workflows/.github/workflows/ci-python.yml@v1
-    with:
-      codecov_upload: true
-      notify_teams: true
-      build_package_inputs: |
-        dependencies: |
-          ecmwf/ecbuild
-          ecmwf/eckit
-          ecmwf/odc
-        dependency_branch: develop
-        self_build: false
-    secrets:
-      pypi_username: ${{ secrets.PYPI_USERNAME }}
-      pypi_password: ${{ secrets.PYPI_PASSWORD }}
-      incoming_webhook: ${{ secrets.MS_TEAMS_INCOMING_WEBHOOK }}
+    # Calls a reusable CI workflow to qa, test & deploy the current repository.
+    #   It will pull in all needed dependencies and produce a code coverage report on success.
+    #   If all checks were successful and a new release tag pushed, the package will be published on PyPI.
+    #   In case the job fails, a message will be posted to a Microsoft Teams channel.
+    ci:
+        name: ci
+        uses: ecmwf-actions/reusable-workflows/.github/workflows/ci-python.yml@v1
+        with:
+            codecov_upload: true
+            notify_teams: true
+            build_package_inputs: |
+                dependencies: |
+                  ecmwf/ecbuild
+                  ecmwf/eckit
+                  ecmwf/odc
+                dependency_branch: develop
+                self_build: false
+        secrets:
+            pypi_username: ${{ secrets.PYPI_USERNAME }}
+            pypi_password: ${{ secrets.PYPI_PASSWORD }}
+            incoming_webhook: ${{ secrets.MS_TEAMS_INCOMING_WEBHOOK }}
 ```
 
 ### Inputs
@@ -244,18 +243,17 @@ Public URL of the Microsoft Teams incoming webhook. To get the value, make sure 
 
 ```yaml
 jobs:
-
-  # Calls a reusable CI NodeJS workflow to qa & test & deploy the current repository.
-  #   It will install dependencies and produce a code coverage report on success.
-  #   In case the job fails, a message will be posted to a Microsoft Teams channel.
-  ci:
-    name: ci
-    uses: ecmwf-actions/reusable-workflows/.github/workflows/ci-node.yml@v1
-    with:
-      codecov_upload: true
-      notify_teams: true
-    secrets:
-      incoming_webhook: ${{ secrets.MS_TEAMS_INCOMING_WEBHOOK }}
+    # Calls a reusable CI NodeJS workflow to qa & test & deploy the current repository.
+    #   It will install dependencies and produce a code coverage report on success.
+    #   In case the job fails, a message will be posted to a Microsoft Teams channel.
+    ci:
+        name: ci
+        uses: ecmwf-actions/reusable-workflows/.github/workflows/ci-node.yml@v1
+        with:
+            codecov_upload: true
+            notify_teams: true
+        secrets:
+            incoming_webhook: ${{ secrets.MS_TEAMS_INCOMING_WEBHOOK }}
 ```
 
 ### Inputs
@@ -321,14 +319,13 @@ Public URL of the Microsoft Teams incoming webhook. To get the value, make sure 
 
 ```yaml
 jobs:
-
-  # Calls a reusable CI workflow to build & check the documentation in the current repository.
-  #   It will install required system dependencies and test Read the Docs build process.
-  docs:
-    name: docs
-    uses: ecmwf-actions/reusable-workflows/.github/workflows/docs.yml@v1
-    with:
-      system_dependencies: doxygen pandoc
+    # Calls a reusable CI workflow to build & check the documentation in the current repository.
+    #   It will install required system dependencies and test Read the Docs build process.
+    docs:
+        name: docs
+        uses: ecmwf-actions/reusable-workflows/.github/workflows/docs.yml@v1
+        with:
+            system_dependencies: doxygen pandoc
 ```
 
 ### Inputs
@@ -369,6 +366,39 @@ The source repository reference, in case it differs from the current one.
 **Default:** `${{ github.ref }}`
 **Type:** `string`
 
+## qa-precommit
+
+### Usage
+
+```yaml
+on:
+    push:
+    pull_request_target:
+        types: [opened, synchronize, reopened]
+
+jobs:
+    quality:
+        uses: ecmwf-actions/reusable-workflows/.github/workflows/qa-precommit-run.yml@v2
+        with:
+            skip_hooks: 'no-commit-to-branch'
+```
+
+### Inputs
+
+#### `python-version`
+
+Optional, pin to use a specific Python version
+**Default:** `'3.x'`
+**Type:** `string`
+**Example:** `'3.9'`
+
+#### `skip-hooks`
+
+Optional, a comma-separated string of pre-commit hooks to skip.
+**Default:** `''`
+**Type:** `string`
+**Example:** `'no-commit-to-branch,black'`
+
 ## sync.yml
 
 ### Usage
@@ -376,35 +406,33 @@ The source repository reference, in case it differs from the current one.
 ```yaml
 # Controls when the workflow will run
 on:
+    # Trigger the workflow on all pushes
+    push:
+        branches:
+            - '**'
+        tags:
+            - '**'
 
-  # Trigger the workflow on all pushes
-  push:
-    branches:
-    - '**'
-    tags:
-    - '**'
-
-  # Trigger the workflow when a branch or tag is deleted
-  delete: ~
+    # Trigger the workflow when a branch or tag is deleted
+    delete: ~
 
 jobs:
-
-  # Calls a reusable CI workflow to sync the current with a remote repository.
-  #   It will correctly handle addition of any new and removal of existing Git objects.
-  sync:
-    name: sync
-    uses: ecmwf-actions/reusable-workflows/.github/workflows/sync.yml@v1
-    secrets:
-      target_repository: ${{ secrets.BITBUCKET_REPOSITORY }}
-      target_username: ${{ secrets.BITBUCKET_USERNAME }}
-      target_token: ${{ secrets.BITBUCKET_PAT }}
+    # Calls a reusable CI workflow to sync the current with a remote repository.
+    #   It will correctly handle addition of any new and removal of existing Git objects.
+    sync:
+        name: sync
+        uses: ecmwf-actions/reusable-workflows/.github/workflows/sync.yml@v1
+        secrets:
+            target_repository: ${{ secrets.BITBUCKET_REPOSITORY }}
+            target_username: ${{ secrets.BITBUCKET_USERNAME }}
+            target_token: ${{ secrets.BITBUCKET_PAT }}
 ```
 
 ### Inputs
 
 #### `sync_repository_inputs`
 
-Optional [inputs for the sync-repository] action, provided as a YAML object value. Note that some values  may be overwritten by provided secrets with same name.
+Optional [inputs for the sync-repository] action, provided as a YAML object value. Note that some values may be overwritten by provided secrets with same name.
 **Default:** `''`
 **Type:** `string`
 
@@ -431,22 +459,22 @@ The user access token with read access to the source repository, must be URL-enc
 **Required** The user access token with write access to the target repository, must be URL-encoded.
 **Example:** `...`
 
-
 ## label-pr.yml
+
 Manages labels on public pull requests. `contributor` label is added when a PR from public fork is opened. Removes label `approved-for-ci` when pull request HEAD changes.
+
 ### Usage
 
 ```yaml
 on:
-  # trigger the pull request is opened or pushed to
-  pull_request_target:
-    types: [opened, synchronize]
+    # trigger the pull request is opened or pushed to
+    pull_request_target:
+        types: [opened, synchronize]
 
 jobs:
-  label:
-    uses: ecmwf-actions/reusable-workflows/.github/workflows/pr-label.yml@v2
+    label:
+        uses: ecmwf-actions/reusable-workflows/.github/workflows/pr-label.yml@v2
 ```
-
 
 ## Development
 


### PR DESCRIPTION
We are using pre-commit hooks on anemoi.

These include configuraitons for flaking, linting, and other coding conventions, that would be great to check server-side.

(In fact, we do already, this would just make the workflow reusable.)