### PR TITLE
Pytest reusable workflow from pyproject with a markdown report

### DIFF
--- a/.github/workflows/qa-pytest-pyproject.yml
+++ b/.github/workflows/qa-pytest-pyproject.yml
@@ -8,11 +8,6 @@ on:
         required: false
         default: '3.x'
         type: string
-      runs-on:
-        description: Platform to run the test on
-        required: false
-        default: 'ubuntu-latest'
-        type: string
       optional-dependencies:
         description: The optional dependencies to install.
         required: false
@@ -26,7 +21,12 @@ on:
 
 jobs:
   tests:
-    runs-on: ${{ inputs.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: ["ubuntu-latest", "macos-latest"]
+    name: Run pytest with Python ${{ inputs.python-version }} on ${{ matrix.platform }}
+    runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ inputs.python-version }}

--- a/.github/workflows/qa-pytest-pyproject.yml
+++ b/.github/workflows/qa-pytest-pyproject.yml
@@ -3,17 +3,17 @@ name: Run pytest tests installation from pyproject toml with report
 on:
   workflow_call:
     inputs:
-      python_version:
+      python-version:
         description: The version of Python binary to use.
         required: false
         default: '3.x'
         type: string
-      optional_dependencies:
+      optional-dependencies:
         description: The optional dependencies to install.
         required: false
         default: 'all,tests'
         type: string
-      skip_tests:
+      skip-tests:
         description: The pytest marks to pass to `-m` command.
         required: false
         default: ''
@@ -24,28 +24,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ inputs.python_version }}
+      - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ inputs.python_version }}
+          python-version: ${{ inputs.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install .[${{ inputs.optional_dependencies }}]
+          python -m pip install .[${{ inputs.optional-dependencies }}]
           python -m pip install pytest-md pytest-emoji
       - name: Test with pytest
         id: pytest
         run: |
-          REPORT=pytest_${{ inputs.python_version }}.md
+          REPORT=pytest_${{ inputs.python-version }}.md
           echo "report-path=$REPORT" >> $GITHUB_OUTPUT
-          pytest -v -m "${{ inputs.skip_tests }}" --emoji --md $REPORT
+          pytest -v -m "${{ inputs.skip-tests }}" --emoji --md $REPORT
         shell: bash -el {0}
       - name: Add report to summary
         if: always()
         run: |
           echo "::group::..."
-          FINAL_REPORT=pytest_report_${{ inputs.python_version }}.md
-          echo "# Test report (python ${{ inputs.python_version }})" > "$FINAL_REPORT"
+          FINAL_REPORT=pytest_report_${{ inputs.python-version }}.md
+          echo "# Test report (python ${{ inputs.python-version }})" > "$FINAL_REPORT"
           echo "<details><summary>Click to expand!</summary>" >> "$FINAL_REPORT"
           report_variable=$(tail -n+2 ${{ steps.pytest.outputs.report-path }})
           echo "$report_variable" >> "$FINAL_REPORT"

--- a/.github/workflows/qa-pytest-pyproject.yml
+++ b/.github/workflows/qa-pytest-pyproject.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: '3.x'
         type: string
+      runs-on:
+        description: Platform to run the test on
+        required: false
+        default: 'ubuntu-latest'
+        type: string
       optional-dependencies:
         description: The optional dependencies to install.
         required: false
@@ -21,7 +26,7 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ inputs.python-version }}

--- a/.github/workflows/qa-pytest-pyproject.yml
+++ b/.github/workflows/qa-pytest-pyproject.yml
@@ -1,0 +1,58 @@
+name: Run pytest tests installation from pyproject toml with report
+
+on:
+  workflow_call:
+    inputs:
+      python_version:
+        description: The version of Python binary to use.
+        required: false
+        default: '3.x'
+        type: string
+      optional_dependencies:
+        description: The optional dependencies to install.
+        required: false
+        default: 'all,tests'
+        type: string
+      skip_tests:
+        description: The pytest marks to pass to `-m` command.
+        required: false
+        default: ''
+        type: string
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ inputs.python_version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python_version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[${{ inputs.optional_dependencies }}]
+          python -m pip install pytest-md pytest-emoji
+      - name: Test with pytest
+        id: pytest
+        run: |
+          REPORT=pytest_${{ inputs.python_version }}.md
+          echo "report-path=$REPORT" >> $GITHUB_OUTPUT
+          pytest -v -m "${{ inputs.skip_tests }}" --emoji --md $REPORT
+        shell: bash -el {0}
+      - name: Add report to summary
+        if: always()
+        run: |
+          echo "::group::..."
+          FINAL_REPORT=pytest_report_${{ inputs.python_version }}.md
+          echo "# Test report (python ${{ inputs.python_version }})" > "$FINAL_REPORT"
+          echo "<details><summary>Click to expand!</summary>" >> "$FINAL_REPORT"
+          report_variable=$(tail -n+2 ${{ steps.pytest.outputs.report-path }})
+          echo "$report_variable" >> "$FINAL_REPORT"
+          echo "</details>" >> "$FINAL_REPORT"
+          cat "$FINAL_REPORT" >> "$GITHUB_STEP_SUMMARY"
+          echo "::endgroup::"
+          echo
+          echo "====================================================================================="
+          echo Markdown summaries: "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          echo "====================================================================================="

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A collection of [reusable GitHub workflows] for ECMWF repositories.
 -   [ci-node.yml](#ci-nodeyml): Continuous Integration workflow for NodeJS-based projects
 -   [docs.yml](#docsyml): Workflow for testing Sphinx-based documentation
 -   [qa-precommit-run.yml](#qa-precommit): Runs the pre-commit hooks on all files server-side as a QA drop-in.
+-   [qa-pytest-pyproject.yml](#qa-pytest-pyproject): Runs pytest after a `pyproject.toml` install with a markdown report.
 -   [sync.yml](#syncyml): Workflow for syncing a Git repository
 
 [Samples]
@@ -398,6 +399,54 @@ Optional, a comma-separated string of pre-commit hooks to skip.
 **Default:** `''`
 **Type:** `string`
 **Example:** `'no-commit-to-branch,black'`
+
+## qa-pytest-pyproject
+
+### Usage
+
+```yaml
+on:
+    push:
+    pull_request_target:
+        types: [opened, synchronize, reopened]
+
+jobs:
+    checks:
+        strategy:
+            matrix:
+                python-version: ['3.9', '3.10']
+        uses: ecmwf-actions/reusable-workflows/.github/workflows/qa-pytest-pyproject.yml@v2
+        with:
+            python-version: ${{ matrix.python-version }}
+```
+
+### Inputs
+
+#### `python-version`
+
+Optional, the version of Python binary to use.
+
+**Default:** `'3.x'`
+**Type:** `string`
+**Example:** `'3.9'`
+
+#### `optional-dependencies`
+
+Optional, optional dependencies to install from package to be tested.
+
+**Default:** `'all,tests'`
+**Type:** `string`
+**Example:** `dev,tests,third_dependency_group`
+
+#### `skip-tests`
+
+Optional, the pytest marks to pass to the `-m` command flag.
+
+Expands in `pytest -v -m "${{ inputs.skip-tests }}"` to coordinate marked tests.
+
+**Default:** `''`
+**Type:** `string`
+**Example:** `'no gpu'`
 
 ## sync.yml
 


### PR DESCRIPTION
This install the testable dependency with `.[all,tests]` where `all,tests` is configurable.

It also generates a github step summary in markdown.