### PR TITLE
ci(pytest): Make installation skippable in pytest

### DIFF
--- a/.github/workflows/qa-pytest-pyproject.yml
+++ b/.github/workflows/qa-pytest-pyproject.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: ''
         type: string
+      install-dependencies:
+        description: Install dependencies unless was done setup externally.
+        required: false
+        default: true
+        type: boolean
       job-summary:
         description: Print job summary on GitHub
         required: false
@@ -49,6 +54,7 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
       - name: Install dependencies
+        if: ${{ inputs.install-dependencies }}
         run: |
           python -m pip install --upgrade pip
           python -m pip install .[${{ inputs.optional-dependencies }}]

--- a/README.md
+++ b/README.md
@@ -438,6 +438,16 @@ Optional, optional dependencies to install from package to be tested.
 **Type:** `string`
 **Example:** `dev,tests,third_dependency_group`
 
+#### `install-dependencies`
+
+Optional, perform or skip dependency installation.
+
+This enables the external installation of dependencies.
+
+**Default:** `true`
+**Type:** `boolean`
+**Example:** `false`
+
 #### `skip-tests`
 
 Optional, the pytest marks to pass to the `-m` command flag.


### PR DESCRIPTION
This introduces a input parameter for the pytest action to skip the pip installation.