### PR TITLE
Add Github HPC actions for ecflow

### DIFF
--- a/hpc/ecflow/monitor-suite/action.yml
+++ b/hpc/ecflow/monitor-suite/action.yml
@@ -1,0 +1,76 @@
+name: monitor-ecflow-suite
+description: |
+  A Github action to monitor a suite status deployed on an ecflow server.
+inputs:
+  troika_user:
+    description: User used to submit troika job.
+    required: true
+  sbatch_options:
+    description: List of SBATCH directives
+    required: false
+  site:
+    description: HPC site name.
+    required: false
+    default: hpc-batch
+  suite_name:
+    description: Name of the suite.
+    required: true
+  ecflow_host:
+    description: ecflow server hostname.
+    required: true
+  ecflow_port:
+    description: ecflow server port.
+    required: true
+  delay:
+    description: Delay in seconds between two ecflow client queries to check the status of the suite.
+    required: false
+    default: 60
+  timeout:
+    description: Timeout in seconds to consider the suite lost.
+    required: false
+    default: 3600
+runs:
+  using: composite
+  steps:
+    - name: Remove suite from ecflow server
+      uses: ecmwf-actions/reusable-workflows/ci-hpc-generic@v2
+      with:
+        template: |
+          set -eux
+          # Load modules of interest
+          module load ecflow
+
+          # Set ecflow server variables
+          export ECF_HOST=${{ inputs.ecflow_host }}
+          export ECF_PORT=${{ inputs.ecflow_port }}
+
+          # Suite status
+          COMPLETE_STATUS=complete
+          ABORTED_STATUS=aborted
+          STATUS=""
+
+          # Check the suite status every DELAY seconds during at most TIMEOUT seconds.
+          # If the suite is not complete after TIMEOUT seconds, exit with an error.
+          TIMEOUT=${{ inputs.timeout }}  # seconds
+          DELAY=${{ inputs.delay }}  # seconds
+          TIME=0  # initialisation
+
+          while [[ "$STATUS" != "$COMPLETE_STATUS" ]]; do
+              STATUS=$(ecflow_client --query state /${{ env.suite_name }})
+              # Check for errors
+              if [ "$STATUS" == "$ABORTED_STATUS" ]; then
+                  echo "Suite status is aborted. Exiting with an error."
+                  exit 1
+              fi
+              # Sleep and check for timeout
+              if [ $TIME -lt $TIMEOUT ]; then
+                  sleep $DELAY
+                  TIME=$((TIME+$DELAY))
+              else
+                  echo "Timeout is reached. Exiting with an error."
+                  exit 1
+              fi
+          done
+        sbatch_options: ${{ inputs.sbatch_options }}
+        troika_user: ${{ inputs.troika_user }}
+        site: ${{ inputs.site }}

--- a/hpc/ecflow/monitor-suite/action.yml
+++ b/hpc/ecflow/monitor-suite/action.yml
@@ -32,7 +32,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Remove suite from ecflow server
+    - name: Monitor suite from ecflow server
       uses: ecmwf-actions/reusable-workflows/ci-hpc-generic@v2
       with:
         template: |

--- a/hpc/ecflow/monitor-suite/action.yml
+++ b/hpc/ecflow/monitor-suite/action.yml
@@ -56,7 +56,7 @@ runs:
           TIME=0  # initialisation
 
           while [[ "$STATUS" != "$COMPLETE_STATUS" ]]; do
-              STATUS=$(ecflow_client --query state /${{ env.suite_name }})
+              STATUS=$(ecflow_client --query state /${{ inputs.suite_name }})
               # Check for errors
               if [ "$STATUS" == "$ABORTED_STATUS" ]; then
                   echo "Suite status is aborted. Exiting with an error."

--- a/hpc/ecflow/remove-suite/action.yml
+++ b/hpc/ecflow/remove-suite/action.yml
@@ -1,0 +1,47 @@
+name: remove-ecflow-suite
+description: |
+  A Github action to remove a suite deployed on an ecflow server.
+inputs:
+  troika_user:
+    description: User used to submit troika job.
+    required: true
+  sbatch_options:
+    description: List of SBATCH directives
+    required: false
+  site:
+    description: HPC site name.
+    required: false
+    default: hpc-batch
+  suite_name:
+    description: Name of the suite.
+    required: true
+  ecflow_host:
+    description: ecflow server hostname.
+    required: true
+  ecflow_port:
+    description: ecflow server port.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Remove suite from ecflow server
+      uses: ecmwf-actions/reusable-workflows/ci-hpc-generic@v2
+      with:
+        template: |
+          set -eux
+          echo "Job is running on ${{ runner.os }}"
+
+          # Load modules of interest
+          module load ecflow
+
+          # Set ecflow server variables
+          export ECF_HOST=${{ env.ecflow_server }}
+          export ECF_PORT=${{ env.ecflow_port }}
+
+          # Do some cleaning if the suite is complete
+          if [ $(ecflow_client --query state /${{ env.suite_name }}) == complete ]; then
+              ecflow_client --delete=force yes /${{ env.suite_name }}
+          fi
+        sbatch_options: ${{ inputs.sbatch_options }}
+        troika_user: ${{ inputs.troika_user }}
+        site: ${{ inputs.site }}

--- a/hpc/ecflow/remove-suite/action.yml
+++ b/hpc/ecflow/remove-suite/action.yml
@@ -35,12 +35,12 @@ runs:
           module load ecflow
 
           # Set ecflow server variables
-          export ECF_HOST=${{ env.ecflow_server }}
-          export ECF_PORT=${{ env.ecflow_port }}
+          export ECF_HOST=${{ inputs.ecflow_server }}
+          export ECF_PORT=${{ inputs.ecflow_port }}
 
           # Do some cleaning if the suite is complete
-          if [ $(ecflow_client --query state /${{ env.suite_name }}) == complete ]; then
-              ecflow_client --delete=force yes /${{ env.suite_name }}
+          if [ $(ecflow_client --query state /${{ inputs.suite_name }}) == complete ]; then
+              ecflow_client --delete=force yes /${{ inputs.suite_name }}
           fi
         sbatch_options: ${{ inputs.sbatch_options }}
         troika_user: ${{ inputs.troika_user }}

--- a/hpc/ecflow/remove-suite/action.yml
+++ b/hpc/ecflow/remove-suite/action.yml
@@ -35,7 +35,7 @@ runs:
           module load ecflow
 
           # Set ecflow server variables
-          export ECF_HOST=${{ inputs.ecflow_server }}
+          export ECF_HOST=${{ inputs.ecflow_host }}
           export ECF_PORT=${{ inputs.ecflow_port }}
 
           # Do some cleaning if the suite is complete

--- a/hpc/ecflow/run-suite/action.yml
+++ b/hpc/ecflow/run-suite/action.yml
@@ -35,7 +35,7 @@ runs:
           module load ecflow
 
           # Set ecflow server variables
-          export ECF_HOST=${{ inputs.ecflow_server }}
+          export ECF_HOST=${{ inputs.ecflow_host }}
           export ECF_PORT=${{ inputs.ecflow_port }}
 
           # Run the suite

--- a/hpc/ecflow/run-suite/action.yml
+++ b/hpc/ecflow/run-suite/action.yml
@@ -35,12 +35,12 @@ runs:
           module load ecflow
 
           # Set ecflow server variables
-          export ECF_HOST=${{ env.ecflow_server }}
-          export ECF_PORT=${{ env.ecflow_port }}
+          export ECF_HOST=${{ inputs.ecflow_server }}
+          export ECF_PORT=${{ inputs.ecflow_port }}
 
           # Run the suite
-          ecflow_client --begin=/${{ env.suite_name }}
-          ecflow_client --resume=/${{ env.suite_name }}
+          ecflow_client --begin=/${{ inputs.suite_name }}
+          ecflow_client --resume=/${{ inputs.suite_name }}
         sbatch_options: ${{ inputs.sbatch_options }}
         troika_user: ${{ inputs.troika_user }}
         site: ${{ inputs.site }}

--- a/hpc/ecflow/run-suite/action.yml
+++ b/hpc/ecflow/run-suite/action.yml
@@ -1,0 +1,46 @@
+name: run-ecflow-suite
+description: |
+  A Github action to run a suite deployed on an ecflow server.
+inputs:
+  troika_user:
+    description: User used to submit troika job.
+    required: true
+  sbatch_options:
+    description: List of SBATCH directives
+    required: false
+  site:
+    description: HPC site name.
+    required: false
+    default: hpc-batch
+  suite_name:
+    description: Name of the suite.
+    required: true
+  ecflow_host:
+    description: ecflow server hostname.
+    required: true
+  ecflow_port:
+    description: ecflow server port.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Remove suite from ecflow server
+      uses: ecmwf-actions/reusable-workflows/ci-hpc-generic@v2
+      with:
+        template: |
+          set -eux
+          echo "Job is running on ${{ runner.os }}"
+
+          # Load modules of interest
+          module load ecflow
+
+          # Set ecflow server variables
+          export ECF_HOST=${{ env.ecflow_server }}
+          export ECF_PORT=${{ env.ecflow_port }}
+
+          # Run the suite
+          ecflow_client --begin=/${{ env.suite_name }}
+          ecflow_client --resume=/${{ env.suite_name }}
+        sbatch_options: ${{ inputs.sbatch_options }}
+        troika_user: ${{ inputs.troika_user }}
+        site: ${{ inputs.site }}

--- a/hpc/ecflow/run-suite/action.yml
+++ b/hpc/ecflow/run-suite/action.yml
@@ -24,7 +24,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Remove suite from ecflow server
+    - name: Run suite from ecflow server
       uses: ecmwf-actions/reusable-workflows/ci-hpc-generic@v2
       with:
         template: |

--- a/hpc/ecflow/wait-for-ecflow-suite-to-complete/action.yml
+++ b/hpc/ecflow/wait-for-ecflow-suite-to-complete/action.yml
@@ -1,6 +1,6 @@
-name: monitor-ecflow-suite
+name: wait-for-ecflow-suite-to-complete
 description: |
-  A Github action to monitor a suite status deployed on an ecflow server.
+  A Github action to check that the suite status is complete on an ecflow server.
 inputs:
   troika_user:
     description: User used to submit troika job.


### PR DESCRIPTION
This PR aims to add actions related to ecflow server and the HPC. 

The idea is to simplify the integration test of the ai-suites repo: https://github.com/ecmwf/ai-suites and to reuse some components in other workflows related to suite execution on HPC in different GIthub repo. 

The PR contains three actions to run, monitor (track) and remove the suite.

We (with https://github.com/corentincarton) thought that the actions could be stored in dedicated repositories:
```
hpc/
└── ecflow
    ├── monitor-suite
    │   └── action.yml
    ├── remove-suite
    │   └── action.yml
    └── run-suite
        └── action.yml
```