### PR TITLE
Add exclude to schemas directory for anemoi-inference docs

### DIFF
--- a/sync-files/anemoi/.pre-commit-config.yaml
+++ b/sync-files/anemoi/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
   rev: v0.0.14
   hooks:
   - id: rstfmt
-    exclude: 'cli/.*' # Because we use argparse
+    exclude: '(cli|schemas)/.*' # Because we use argparse and pydantic sphinx directives
 - repo: https://github.com/tox-dev/pyproject-fmt
   rev: "v2.5.0"
   hooks:


### PR DESCRIPTION
Adds an exclude for the schemas directory in the anemoi-inference which contains a pydantic related sphinx directive that rstfmt doesn't like. See https://github.com/ecmwf/anemoi-inference/actions/runs/13031075408/job/36410194479