### PR TITLE
Update anemoi sync files to fix initial broadcast

### DIFF
--- a/sync-files/anemoi/.github/workflows/downstream-ci-hpc.yml
+++ b/sync-files/anemoi/.github/workflows/downstream-ci-hpc.yml
@@ -44,11 +44,11 @@ jobs:
       codecov_upload: true
     secrets: inherit
 
-   # Build downstream packages on HPC
-  downstream-ci-hpc:
-    name: downstream-ci-hpc
-    if: {% raw %}${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}{% endraw %}
-    uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci-hpc.yml@main
-    with:
-      {{ repo_name }}: ecmwf/{{ repo_name }}{% raw %}@${{ github.event.pull_request.head.sha || github.sha }}{% endraw %}
-    secrets: inherit
+  # # Build downstream packages on HPC
+  # downstream-ci-hpc:
+  #   name: downstream-ci-hpc
+  #   if: {% raw %}${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}{% endraw %}
+  #   uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci-hpc.yml@main
+  #   with:
+  #     {{ repo_name }}: ecmwf/{{ repo_name }}{% raw %}@${{ github.event.pull_request.head.sha || github.sha }}{% endraw %}
+  #   secrets: inherit

--- a/sync-files/anemoi/.github/workflows/pr-label-conventional-commits.yml
+++ b/sync-files/anemoi/.github/workflows/pr-label-conventional-commits.yml
@@ -8,6 +8,9 @@ on:
     types:
       [opened, reopened, labeled, unlabeled]
 
+permissions:
+  pull-requests: write
+
 jobs:
   assign-labels:
     runs-on: ubuntu-latest

--- a/sync-files/anemoi/.release-please-config.json
+++ b/sync-files/anemoi/.release-please-config.json
@@ -7,7 +7,7 @@
   "changelog-type": "github",
   "include-component-in-tag": false,
   "include-v-in-tag": false,
-  "draft": true,
+  "draft-pull-request": true,
   "pull-request-title-pattern": "chore${scope}: Preparing Next Release for ${component} ${version}",
   "pull-request-header": ":robot: Automated Release PR\n\nThis PR was created by `release-please` to prepare the next release. Once merged:\n\n1. A new version tag will be created\n2. A GitHub release will be published\n3. The changelog will be updated\n\nChanges to be included in the next release:",
   "pull-request-footer": "> [!IMPORTANT]\n> :warning: Merging this PR will:\n> - Create a new release\n> - Trigger deployment pipelines\n> - Update package versions\n\n **Before merging:**\n - Ensure all tests pass\n - Review the changelog carefully\n - Get required approvals\n\n [Release-please documentation](https://github.com/googleapis/release-please)",

--- a/sync-files/general/python/.github/dependabot.yml
+++ b/sync-files/general/python/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "monthly"
+# - package-ecosystem: "github-actions"
+#   directory: "/"
+#   schedule:
+#     interval: "monthly"

--- a/sync-files/sync.yml
+++ b/sync-files/sync.yml
@@ -63,6 +63,7 @@ group:
     exclude: |
       .release-please-manifest.json
       .github/PULL_REQUEST_TEMPLATE/pull_request_template-core.md
+      .github/workflows/push-to-private.yml
   repos: |
     ecmwf/anemoi-inference
 
@@ -79,6 +80,7 @@ group:
     exclude: |
       .release-please-manifest.json
       .github/PULL_REQUEST_TEMPLATE/pull_request_template-core.md
+      .github/workflows/push-to-private.yml
   repos: |
     ecmwf/anemoi-registry
 
@@ -95,6 +97,7 @@ group:
     exclude: |
       .release-please-manifest.json
       .github/PULL_REQUEST_TEMPLATE/pull_request_template-core.md
+      .github/workflows/push-to-private.yml
   repos: |
     ecmwf/anemoi-transform
 
@@ -111,6 +114,7 @@ group:
     exclude: |
       .release-please-manifest.json
       .github/PULL_REQUEST_TEMPLATE/pull_request_template-core.md
+      .github/workflows/push-to-private.yml
   repos: |
     ecmwf/anemoi-utils
 


### PR DESCRIPTION
Update sync config and files in anemoi sync folder in order to:

- update release-please config to draft-pull-request
- turn off downstream-ci-hpc temporarily
- give pr labeller write permission
- exclude push-to-private action for repos without private counterpart
- remove github-actions from dependabot