### PR TITLE
Fix exclusions in sync workflow -- Version1

### DIFF
--- a/.github/workflows/sync-files-to-repos.yml
+++ b/.github/workflows/sync-files-to-repos.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Run Repo File Sync Action
-        uses: BetaHuhn/repo-file-sync-action@v1
+        uses: BetaHuhn/repo-file-sync-action@v1.19
         with:
           GH_PAT: ${{ secrets.REPO_SYNC_ACTION_PAT }}
           GIT_EMAIL: "150700357+DeployDuck@users.noreply.github.com"

--- a/sync-files/sync.yml
+++ b/sync-files/sync.yml
@@ -81,6 +81,7 @@ group:
       .release-please-manifest.json
       .github/PULL_REQUEST_TEMPLATE/pull_request_template-core.md
       .github/workflows/push-to-private.yml
+      .github/workflows/downstream-ci-hpc.yml
   repos: |
     ecmwf/anemoi-registry
 

--- a/sync-files/sync.yml
+++ b/sync-files/sync.yml
@@ -127,21 +127,21 @@ group:
       year: 2024-2025
       authors: Anemoi Contributors
     exclude:
-      - .github
+      - .github/dependabot.yml
   - source: sync-files/general/python/
     dest: models/
     template:
       year: 2024-2025
       authors: Anemoi Contributors
     exclude:
-      - .github
+      - .github/dependabot.yml
   - source: sync-files/general/python/
     dest: training/
     template:
       year: 2024-2025
       authors: Anemoi Contributors
     exclude:
-      - .github
+      - .github/dependabot.yml
   - source: sync-files/anemoi/CONTRIBUTORS.md
     dest: CONTRIBUTORS.md
     template:


### PR DESCRIPTION
Fix sync workflow.

Problem:
The option to exclude files/subfolders from the sync is broken in versions >=1.20 in the dependency repo-file-sync-action (see [this PR](https://github.com/BetaHuhn/repo-file-sync-action/pull/274/files)). 

Solution:
Temporarily revert to version 1.19 before the introduction of the feature to exclude subfolders (which breaks the exclusion of files) until that feature is fixed.