### PR TITLE
Act/py wrap wheel/reuploads

### DIFF
--- a/.github/workflows/python-wrapper-wheel.yml
+++ b/.github/workflows/python-wrapper-wheel.yml
@@ -18,6 +18,7 @@ jobs:
   linux-wheel:
     name: Build manylinux_2_28
     strategy:
+      fail-fast: false # NOTE primary reason for fail fast is the failure in the clean up step. Once fixed, consider true
       matrix:  
         # TODO convert this to be matrix-friendly. Note it's a bit tricky since
         # we'd ideally not reexecute the compile step multiple times, but it
@@ -48,6 +49,7 @@ jobs:
   macos-wheel:
     name: Build macos wheel
     strategy:
+      fail-fast: false # NOTE primary reason for fail fast is the failure in the clean up step. Once fixed, consider true
       matrix:
         arch_type: [ARM64, X64]
         python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]

--- a/.github/workflows/python-wrapper-wheel.yml
+++ b/.github/workflows/python-wrapper-wheel.yml
@@ -70,17 +70,18 @@ jobs:
           token: ${{ secrets.GH_REPO_READ_TOKEN }}
       - run: rm -rf proj && git clone --depth=1 --branch="${GITHUB_REF#refs/heads/}" https://github.com/$GITHUB_REPOSITORY proj
       - run: |
-          cd proj && $GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts/prepare_deps.sh ./python_wrapper/buildconfig 3.11
+          uv python install python"${{ matrix.python_version }}"
+          cd proj && $GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts/prepare_deps.sh ./python_wrapper/buildconfig "${{ matrix.python_version }}"
       - run: |
           cd proj
           if [[ -f ./python_wrapper/pre-compile.sh ]] ; then ./python_wrapper/pre-compile.sh ; fi
           PATH="$PATH:$GITHUB_WORKSPACE/ecbuild/bin/" $GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts/compile.sh ./python_wrapper/buildconfig
       - run: |
           cd proj
-          rm -rf /tmp/buildvenv && uv python install python3.11 && uv venv --python python3.11 /tmp/buildvenv && source /tmp/buildvenv/bin/activate && uv pip install build twine delocate setuptools
-          PYTHONPATH=$GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts $GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts/wheel-linux.sh ./python_wrapper/buildconfig 3.11
+          rm -rf /tmp/buildvenv && uv venv --python python"${{ matrix.python_version }}" /tmp/buildvenv && source /tmp/buildvenv/bin/activate && uv pip install build twine delocate setuptools requests
+          PYTHONPATH=$GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts $GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts/wheel-linux.sh ./python_wrapper/buildconfig "${{ matrix.python_version }}"
           if [[ -f ./python_wrapper/post-build.sh ]] ; then ./python_wrapper/post-build.sh ; fi
-          $GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts/test-wheel.sh ./python_wrapper/buildconfig 3.11
+          $GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts/test-wheel.sh ./python_wrapper/buildconfig "${{ matrix.python_version }}"
           PYTHONPATH=$GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts $GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts/upload-pypi.sh ./python_wrapper/buildconfig
         env:
           TWINE_USERNAME: __token__

--- a/.github/workflows/python-wrapper-wheel.yml
+++ b/.github/workflows/python-wrapper-wheel.yml
@@ -39,7 +39,7 @@ jobs:
       - run: cd /proj && PYTHONPATH=/buildscripts /buildscripts/wheel-linux.sh ./python_wrapper/buildconfig "${{ matrix.python_version }}"
       - run: cd /proj && if [[ -f ./python_wrapper/post-build.sh ]] ; then ./python_wrapper/post-build.sh ; fi
       - run: cd /proj && /buildscripts/test-wheel.sh ./python_wrapper/buildconfig "${{ matrix.python_version }}"
-      - run: cd /proj && /buildscripts/upload-pypi.sh ./python_wrapper/buildconfig
+      - run: cd /proj && PYTHONPATH=/buildscripts /buildscripts/upload-pypi.sh ./python_wrapper/buildconfig
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TEST_API_TOKEN }}
@@ -77,11 +77,11 @@ jobs:
           PATH="$PATH:$GITHUB_WORKSPACE/ecbuild/bin/" $GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts/compile.sh ./python_wrapper/buildconfig
       - run: |
           cd proj
-          rm -rf /tmp/buildvenv && uv python install python3.11 && uv venv --python python3.11 /tmp/buildvenv && source /tmp/buildvenv/bin/activate && uv pip install build twine delocate
+          rm -rf /tmp/buildvenv && uv python install python3.11 && uv venv --python python3.11 /tmp/buildvenv && source /tmp/buildvenv/bin/activate && uv pip install build twine delocate setuptools
           PYTHONPATH=$GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts $GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts/wheel-linux.sh ./python_wrapper/buildconfig 3.11
           if [[ -f ./python_wrapper/post-build.sh ]] ; then ./python_wrapper/post-build.sh ; fi
           $GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts/test-wheel.sh ./python_wrapper/buildconfig 3.11
-          $GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts/upload-pypi.sh ./python_wrapper/buildconfig
+          PYTHONPATH=$GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts $GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts/upload-pypi.sh ./python_wrapper/buildconfig
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/python-wrapper-wheel.yml
+++ b/.github/workflows/python-wrapper-wheel.yml
@@ -43,7 +43,7 @@ jobs:
       - run: cd /proj && PYTHONPATH=/buildscripts /buildscripts/upload-pypi.sh ./python_wrapper/buildconfig
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TEST_API_TOKEN }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         # NOTE temporary thing until all the mess gets cleared
       - run: rm -rf ./* ./.git ./.github
   macos-wheel:


### PR DESCRIPTION
Multiple small fixes here:
 - fix pypi token for linux builds
 - actually use the python version from matrix in macos builds
 - fix python install mechanism and packages in macos
 - enable usage of setup_utils in the upload pypi step -- this, in turn with the newest wheelmaker image, makes the uploads to pypi increment build number in case of conflict