### PR TITLE
PyWheelWrap: propagate github ref

### DIFF
--- a/.github/workflows/python-wrapper-wheel.yml
+++ b/.github/workflows/python-wrapper-wheel.yml
@@ -38,7 +38,7 @@ jobs:
       - run: cd /proj && if [[ -f ./python_wrapper/pre-compile.sh ]] ; then ./python_wrapper/pre-compile.sh ; fi
       - run: cd /proj && /buildscripts/compile.sh ./python_wrapper/buildconfig
       - run: cd /proj && if [[ -f ./python_wrapper/post-compile.sh ]] ; then ./python_wrapper/post-compile.sh ; fi
-      - run: cd /proj && PYTHONPATH=/buildscripts /buildscripts/wheel-linux.sh ./python_wrapper/buildconfig "${{ matrix.python_version }}"
+      - run: cd /proj && GITHUB_BRANCH="${GITHUB_REF}" PYTHONPATH=/buildscripts /buildscripts/wheel-linux.sh ./python_wrapper/buildconfig "${{ matrix.python_version }}"
       - run: cd /proj && if [[ -f ./python_wrapper/post-build.sh ]] ; then ./python_wrapper/post-build.sh ; fi
       - run: cd /proj && /buildscripts/test-wheel.sh ./python_wrapper/buildconfig "${{ matrix.python_version }}"
       - run: cd /proj && PYTHONPATH=/buildscripts /buildscripts/upload-pypi.sh ./python_wrapper/buildconfig
@@ -83,7 +83,7 @@ jobs:
       - run: |
           cd proj
           rm -rf /tmp/buildvenv && uv venv --python python"${{ matrix.python_version }}" /tmp/buildvenv && source /tmp/buildvenv/bin/activate && uv pip install build twine delocate setuptools requests
-          PYTHONPATH=$GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts $GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts/wheel-linux.sh ./python_wrapper/buildconfig "${{ matrix.python_version }}"
+          GITHUB_BRANCH="${GITHUB_REF}" PYTHONPATH=$GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts $GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts/wheel-linux.sh ./python_wrapper/buildconfig "${{ matrix.python_version }}"
           if [[ -f ./python_wrapper/post-build.sh ]] ; then ./python_wrapper/post-build.sh ; fi
           $GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts/test-wheel.sh ./python_wrapper/buildconfig "${{ matrix.python_version }}"
           PYTHONPATH=$GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts $GITHUB_WORKSPACE/ci-utils/wheelmaker/buildscripts/upload-pypi.sh ./python_wrapper/buildconfig


### PR DESCRIPTION
This makes the $GITHUB_REF propagated to particular scripts inside the action. We use it to drive the release channel -- all branches except for `main`/`master` end up publishing `dev` wheels, to not affect regular usage