### PR TITLE
Fix repo subdir usage for Python dependencies

### DIFF
--- a/ci-python/action.yml
+++ b/ci-python/action.yml
@@ -140,6 +140,7 @@ runs:
           git remote add origin https://${{ inputs.github_token }}@github.com/$owner/$repo.git
           git fetch --depth 1 origin $ref
           git checkout FETCH_HEAD
+          cd $subdir
           python -m build --sdist
           pip install dist/*
         done <<< "${{ inputs.python_dependencies }}"


### PR DESCRIPTION
To fix this:https://github.com/ecmwf/anemoi-datasets/actions/runs/13386800331/job/37385897262
The situation is that a Python package triggers downstream-ci, which then starts the build of a downstream package which has a dependency which is a Python package contained in a subdirectory of another repo. We currently do not 'cd' into the subdir before installing that pacakge.
The particular case:
* anemoi-datasets triggers the downstream-ci
* this triggers a build of anemoi-training, which depends on anemoi-datasets and also anemoi-models
* in the workflow for anemoi-training, it tries to clone and install anemoi-models, which lives in a subdirectory of anemoi-core. It is at this point that we fail to 'cd' into the subdir 'models' of anemoi-core.